### PR TITLE
chore: fold manifest schema pai/v1 → arc/v1

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — arc package manifest
 # See: https://github.com/the-metafactory/arc
 
-schema: pai/v1
+schema: arc/v1
 type: skill
 namespace: metafactory
 name: agent-state


### PR DESCRIPTION
## What
`schema: pai/v1` → `schema: arc/v1` in `arc-manifest.yaml`.

## Why
arc v0.37.0 deprecates `pai/v1`, folding it to `arc/v1` with a stderr warning (**arc#280**). This is the mechanical sweep step.

## State declaration
agent-state is a **skill** bundle, not an agent — no work-queue state of its own, so no `state:` block (arc#281 stateless-by-default correctly applies).

## Verification
- `bun test` → 81 pass / 0 fail
- Manifest parses; `schema: arc/v1`

Minimal diff — one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)