### PR TITLE
feat(as-012): errands.ts get + annotate — KV read/upsert CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ agent manifest in the metafactory agent platform. One bundle, two SQLite tables,
   `events.ts` (append-only events CLI), `dashboard.ts` (regenerate dashboard.md),
   `retro.ts` (weekly retro). All runnable via `bun`.
 - **Workflows** — `ScaffoldFolders`, `EnqueueWorkItem`, `ClaimWorkItem`, `ResolveWorkItem`,
-  `AppendEvent`, `ReplayPending`, `RegenerateDashboard`, `RetrospectiveSummary`.
+  `GetWorkItem`, `AnnotateWorkItem`, `AppendEvent`, `ReplayPending`, `RegenerateDashboard`,
+  `RetrospectiveSummary`.
 - **Per-instance layout** — `~/.config/<host>/agents/<name>/{state.sqlite, dashboard.md, retros/, CLAUDE.md, context/, persona.md}`
   per the four-folder shape defined in [`forge/design/agent-platform.md`](https://github.com/the-metafactory/forge/blob/main/design/agent-platform.md).
 

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -87,6 +87,146 @@ describe("events.ts CLI flag validation (N1)", () => {
   });
 });
 
+describe("errands.ts get (#12)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "as-cli-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("get on an existing id prints the row as JSON (exit 0)", async () => {
+    await run(
+      ERRANDS,
+      ["enqueue", "--id", "w1", "--kind", "test", "--payload", '{"a":1}'],
+      dir,
+    );
+    const r = await run(ERRANDS, ["get", "--id", "w1"], dir);
+    expect(r.exitCode).toBe(0);
+    const row = JSON.parse(r.stdout.trim()) as { id: string; kind: string };
+    expect(row.id).toBe("w1");
+    expect(row.kind).toBe("test");
+  });
+
+  test("get on a missing id exits 1 with a clear message", async () => {
+    const r = await run(ERRANDS, ["get", "--id", "nope"], dir);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("no such work_item");
+    expect(r.stderr).toContain("nope");
+  });
+});
+
+describe("errands.ts annotate (#12)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "as-cli-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function enqueue(id: string, extra: string[] = []): Promise<void> {
+    await run(
+      ERRANDS,
+      ["enqueue", "--id", id, "--kind", "dev-session", "--payload", "{}", ...extra],
+      dir,
+    );
+  }
+
+  test("annotate merges a JSON object into notes and prints the updated row", async () => {
+    await enqueue("w1");
+    const r = await run(
+      ERRANDS,
+      ["annotate", "--id", "w1", "--notes-json", '{"session_id":"ccs-1"}'],
+      dir,
+    );
+    expect(r.exitCode).toBe(0);
+    const row = JSON.parse(r.stdout.trim()) as { notes: string; status: string };
+    expect(JSON.parse(row.notes)).toEqual({ session_id: "ccs-1" });
+    expect(row.status).toBe("pending");
+  });
+
+  test("annotate emits exactly one work_item_annotated event", async () => {
+    await enqueue("w1");
+    await run(
+      ERRANDS,
+      ["annotate", "--id", "w1", "--notes-json", '{"session_id":"ccs-2"}'],
+      dir,
+    );
+    const tail = await run(EVENTS, ["tail", "--limit", "50"], dir);
+    const types = tail.stdout
+      .trim()
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { type: string; work_item_id: string | null })
+      .filter((e) => e.work_item_id === "w1")
+      .map((e) => e.type)
+      .sort();
+    expect(types).toEqual(["work_item_annotated", "work_item_created"]);
+  });
+
+  test("annotate preserves non-JSON notes under a text key", async () => {
+    await enqueue("w1", ["--notes", "shipped by hand"]);
+    const r = await run(
+      ERRANDS,
+      ["annotate", "--id", "w1", "--notes-json", '{"session_id":"ccs-3"}'],
+      dir,
+    );
+    const row = JSON.parse(r.stdout.trim()) as { notes: string };
+    expect(JSON.parse(row.notes)).toEqual({
+      text: "shipped by hand",
+      session_id: "ccs-3",
+    });
+  });
+
+  test("annotate on a terminal (done) row is allowed and status unchanged", async () => {
+    await enqueue("w1");
+    await run(ERRANDS, ["resolve", "--id", "w1", "--status", "done"], dir);
+    const r = await run(
+      ERRANDS,
+      ["annotate", "--id", "w1", "--notes-json", '{"session_id":"ccs-4"}'],
+      dir,
+    );
+    expect(r.exitCode).toBe(0);
+    const row = JSON.parse(r.stdout.trim()) as { status: string; notes: string };
+    expect(row.status).toBe("done");
+    expect(JSON.parse(row.notes).session_id).toBe("ccs-4");
+  });
+
+  test("annotate with a JSON array exits 2 (must be an object)", async () => {
+    await enqueue("w1");
+    const r = await run(
+      ERRANDS,
+      ["annotate", "--id", "w1", "--notes-json", "[1,2,3]"],
+      dir,
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("must be a JSON object");
+  });
+
+  test("annotate with malformed JSON exits 2", async () => {
+    await enqueue("w1");
+    const r = await run(
+      ERRANDS,
+      ["annotate", "--id", "w1", "--notes-json", "{not json"],
+      dir,
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("invalid --notes-json");
+  });
+
+  test("annotate on a missing id exits 1", async () => {
+    const r = await run(
+      ERRANDS,
+      ["annotate", "--id", "nope", "--notes-json", '{"a":1}'],
+      dir,
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("no such work_item");
+  });
+});
+
 describe("errands.ts CLI does not double-emit events (W2)", () => {
   let dir: string;
   beforeEach(() => {

--- a/__tests__/work-items.test.ts
+++ b/__tests__/work-items.test.ts
@@ -9,6 +9,7 @@ import {
   claimWorkItem,
   resolveWorkItem,
   getWorkItem,
+  annotateWorkItem,
   listWorkItems,
   listPending,
   pendingForReplay,
@@ -327,5 +328,106 @@ describe("pendingForReplay", () => {
     });
     const rows = pendingForReplay(ctx.db, 1_000);
     expect(rows).toHaveLength(0);
+  });
+});
+
+describe("annotateWorkItem (KV upsert surface — #12)", () => {
+  let ctx: ReturnType<typeof freshDb>;
+  beforeEach(() => {
+    ctx = freshDb();
+  });
+  afterEach(() => {
+    ctx.db.close();
+    rmTmp(ctx.dir);
+  });
+
+  test("merges patch into empty notes and stores a JSON object", () => {
+    enqueueWorkItem(ctx.db, { id: "w1", kind: "dev-session", payload: {} });
+    const r = annotateWorkItem(ctx.db, "w1", { session_id: "ccs-123" });
+    expect(JSON.parse(r.row.notes!)).toEqual({ session_id: "ccs-123" });
+  });
+
+  test("merges over an existing JSON-object notes (incoming keys win)", () => {
+    enqueueWorkItem(ctx.db, {
+      id: "w1",
+      kind: "dev-session",
+      payload: {},
+      notes: JSON.stringify({ session_id: "old", host: "grove" }),
+    });
+    const r = annotateWorkItem(ctx.db, "w1", { session_id: "new" });
+    expect(JSON.parse(r.row.notes!)).toEqual({ session_id: "new", host: "grove" });
+  });
+
+  test("preserves non-JSON freeform notes under a `text` key when merging", () => {
+    enqueueWorkItem(ctx.db, {
+      id: "w1",
+      kind: "k",
+      payload: {},
+      notes: "shipped by hand",
+    });
+    const r = annotateWorkItem(ctx.db, "w1", { session_id: "ccs-9" });
+    expect(JSON.parse(r.row.notes!)).toEqual({
+      text: "shipped by hand",
+      session_id: "ccs-9",
+    });
+  });
+
+  test("preserves a JSON array/scalar notes under `text` (non-object JSON)", () => {
+    enqueueWorkItem(ctx.db, {
+      id: "w1",
+      kind: "k",
+      payload: {},
+      notes: JSON.stringify([1, 2, 3]),
+    });
+    const r = annotateWorkItem(ctx.db, "w1", { a: 1 });
+    expect(JSON.parse(r.row.notes!)).toEqual({ text: "[1,2,3]", a: 1 });
+  });
+
+  test("emits a work_item_annotated event with the written keys (W2)", () => {
+    enqueueWorkItem(ctx.db, { id: "w1", kind: "k", payload: {}, owner_agent: "luna" });
+    const r = annotateWorkItem(ctx.db, "w1", { session_id: "ccs-1", extra: true });
+    expect(r.event.type).toBe("work_item_annotated");
+    expect(r.event.work_item_id).toBe("w1");
+    expect(r.event.actor).toBe("luna");
+    expect(JSON.parse(r.event.payload)).toEqual({ keys: ["session_id", "extra"] });
+    const linked = eventsForWorkItem(ctx.db, "w1");
+    expect(linked.map((e) => e.type)).toEqual([
+      "work_item_created",
+      "work_item_annotated",
+    ]);
+  });
+
+  test("is allowed on a terminal row and never changes status (metadata-only)", () => {
+    enqueueWorkItem(ctx.db, { id: "w1", kind: "k", payload: {} });
+    resolveWorkItem(ctx.db, "w1", "done");
+    const r = annotateWorkItem(ctx.db, "w1", { session_id: "ccs-2" });
+    expect(r.row.status).toBe("done");
+    expect(JSON.parse(r.row.notes!).session_id).toBe("ccs-2");
+  });
+
+  test("does not touch kind / payload / owner_agent", () => {
+    enqueueWorkItem(ctx.db, {
+      id: "w1",
+      kind: "dev-session",
+      payload: { hot: "read" },
+      owner_agent: "luna",
+    });
+    const r = annotateWorkItem(ctx.db, "w1", { session_id: "ccs-3" });
+    expect(r.row.kind).toBe("dev-session");
+    expect(r.row.payload).toBe(JSON.stringify({ hot: "read" }));
+    expect(r.row.owner_agent).toBe("luna");
+  });
+
+  test("bumps updated_at", async () => {
+    const e = enqueueWorkItem(ctx.db, { id: "w1", kind: "k", payload: {} });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    const r = annotateWorkItem(ctx.db, "w1", { session_id: "ccs-4" });
+    expect(r.row.updated_at).toBeGreaterThan(e.row.updated_at);
+  });
+
+  test("throws on unknown id", () => {
+    expect(() => annotateWorkItem(ctx.db, "nope", { a: 1 })).toThrow(
+      /no such work_item/,
+    );
   });
 });

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -39,6 +39,10 @@ provides:
       file: skill/Workflows/ClaimWorkItem.md
     - name: ResolveWorkItem
       file: skill/Workflows/ResolveWorkItem.md
+    - name: GetWorkItem
+      file: skill/Workflows/GetWorkItem.md
+    - name: AnnotateWorkItem
+      file: skill/Workflows/AnnotateWorkItem.md
     - name: AppendEvent
       file: skill/Workflows/AppendEvent.md
     - name: ReplayPending
@@ -53,7 +57,7 @@ provides:
       description: "Scaffold per-instance state directory (state.sqlite + dashboard.md + context/ + retros/)"
     - name: errands
       command: bun skill/scripts/errands.ts
-      description: "work_items CLI — list / enqueue / claim / resolve / pending"
+      description: "work_items CLI — list / enqueue / claim / resolve / pending / get / annotate"
     - name: events
       command: bun skill/scripts/events.ts
       description: "events CLI — append / tail / since (append-only timeline)"

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -32,6 +32,8 @@ Each workflow ships as `Workflows/<Name>.md` with a runnable script in `scripts/
 - `EnqueueWorkItem` — insert pending row into `work_items`.
 - `ClaimWorkItem` — atomic `pending → in_flight` transition (emits `work_item_claimed`).
 - `ResolveWorkItem` — terminal transition (`done` or `failed`), append matching event.
+- `GetWorkItem` — read one work item by id as JSON (exit 1 if not found).
+- `AnnotateWorkItem` — merge host metadata (e.g. `session_id`) into a row's `notes`; emits `work_item_annotated`.
 - `AppendEvent` — append-only insert into `events`.
 - `ReplayPending` — `onStart` hook; walks unfinished work items and re-emits.
 - `RegenerateDashboard` — rebuild `dashboard.md` from current state.

--- a/skill/Workflows/AnnotateWorkItem.md
+++ b/skill/Workflows/AnnotateWorkItem.md
@@ -1,0 +1,89 @@
+# Workflow — AnnotateWorkItem
+
+Merge a host-supplied JSON object into an existing work item's `notes` column and
+write a `work_item_annotated` event. This is the small KV-ish **upsert** surface a
+host uses to hang metadata off a work item after creation — the concrete driver is
+the errand→session map behind [cortex#1720 S4b](https://github.com/the-metafactory/cortex/issues/1720)
+(session affinity per correlation chain, `design-agentic-dev-pipeline.md` §3.6b).
+
+Annotation is **metadata-only**. It is NOT a state transition: it never changes
+`status`, `kind`, `payload`, or `owner_agent`. It touches `notes` + `updated_at`
+only, and it is allowed on **any** status — terminal rows included.
+
+## Trigger
+
+Called by a host on its OFF-path (not the awaited hot path) to record host metadata
+against a work item — e.g. writing back a `session_id` after a session starts.
+
+> Latency note (cortex#1720 S4b): the durable write lives here, but the hot
+> warm-resume read stays in-process on the host side. Do **not** put
+> `errands.ts get`/`annotate` subprocesses on a correctness-affecting hot path;
+> agent-state is the durable backing, the host keeps a process-local map for reads
+> and rehydrates on start via `list`.
+
+## Action
+
+```bash
+bun <bundleInstallPath>/skill/scripts/errands.ts annotate \
+  --id <work-item-id> \
+  --notes-json '{"session_id":"ccs-abc123"}'
+```
+
+Behavior:
+
+1. Looks up the row. If missing → exits `1` with `no such work_item id=<id>`.
+2. `--notes-json` MUST parse to a **JSON object**. A malformed string or a JSON
+   array/scalar exits `2` (validated in the CLI before the lib runs).
+3. Derives a base object from the existing `notes` cell (the notes-as-JSON-object
+   contract for this path — see below), shallow-merges the patch over it (patch keys
+   win), and writes the result back as a JSON string.
+4. Bumps `updated_at`. Leaves `status`, `kind`, `payload`, `owner_agent` untouched.
+5. Appends a single `work_item_annotated` event with payload `{ keys: [...] }` (the
+   top-level keys written by this call). Event emission lives in
+   `lib/work-items.ts:annotateWorkItem`; callers MUST NOT also `appendEvent`.
+
+### notes-as-JSON-object contract
+
+`notes` is a `TEXT` column. For the annotate path it is interpreted as a JSON object:
+
+| Existing `notes` cell            | Base used for the merge                    |
+|----------------------------------|--------------------------------------------|
+| `NULL` or empty string           | `{}`                                        |
+| valid JSON object                | that object                                 |
+| non-JSON freeform text           | `{ "text": "<original raw string>" }`       |
+| JSON array / string / number     | `{ "text": "<original raw string>" }`       |
+
+The `text` key is **reserved** for this preservation behavior — an operator's
+freeform note is never silently clobbered; it is carried forward under `text`. The
+merge is a **shallow** override (nested objects are replaced wholesale, not
+deep-merged), keeping the contract predictable.
+
+### Field ownership — who may write what
+
+- **Host-writable (via annotate):** host-namespaced metadata keys on `notes` —
+  e.g. `session_id`, and any other continuity/bookkeeping key the host owns. Hosts
+  should treat `notes` as their scratch object and avoid the reserved `text` key
+  (it holds preserved freeform notes).
+- **Bundle-owned (NEVER writable via annotate):** `status`, `kind`, `payload`, and
+  `owner_agent`. Status transitions go through `claim`/`resolve`; `kind` and
+  `payload` are set once at `enqueue`. `annotate` structurally cannot change them.
+
+## Verify
+
+```bash
+bun scripts/errands.ts get --id <work-item-id>
+bun scripts/events.ts tail --limit 5   # expect a work_item_annotated row
+```
+
+## Anti-pattern
+
+- Using `annotate` to change lifecycle state. It cannot, by design — use
+  `claim`/`resolve`. If you find yourself wanting a status change here, you want a
+  different workflow.
+- Putting `annotate`/`get` on an awaited, correctness-affecting hot path. Keep the
+  hot read in-process; use agent-state as the durable backing only (cortex#1720 S4b).
+- Writing to the reserved `text` key. It holds preserved freeform notes; overwriting
+  it destroys operator context.
+- Calling `appendEvent('work_item_annotated', ...)` after a successful annotate. The
+  lib emits it; doing it again double-records.
+```

--- a/skill/Workflows/GetWorkItem.md
+++ b/skill/Workflows/GetWorkItem.md
@@ -1,0 +1,43 @@
+# Workflow — GetWorkItem
+
+Read a single work item by id and print it as one JSON row. This exposes the
+lib's existing `getWorkItem` at the CLI so hosts can read back a row they
+enqueued/annotated (the read half of the KV-ish surface behind
+[cortex#1720 S4b](https://github.com/the-metafactory/cortex/issues/1720)).
+
+## Trigger
+
+Called by a host that needs the current state of one work item — e.g. to
+rehydrate a process-local map on start, or to inspect `notes` metadata written
+via `annotate`.
+
+> Not for hot paths: rehydrate an in-process map from `list` on start; keep the
+> per-request read in-process. A per-read subprocess regresses latency and turns a
+> correctness-affecting read into a subprocess failure mode (cortex#1720 S4b).
+
+## Action
+
+```bash
+bun <bundleInstallPath>/skill/scripts/errands.ts get --id <work-item-id>
+```
+
+Behavior:
+
+1. Looks up the row by primary key.
+2. If found → prints the full row as a single JSON object on stdout, exits `0`.
+3. If not found → writes `no such work_item id=<id>` to stderr, exits `1`
+   (distinct from the `2` used for flag/usage errors).
+
+## Verify
+
+```bash
+bun scripts/errands.ts get --id <known-id>      # exit 0, JSON row
+bun scripts/errands.ts get --id no-such-id      # exit 1, clear message
+```
+
+## Anti-pattern
+
+- Looping `get` per item to page a queue — use `list`/`pending`, which are indexed
+  and return many rows in one call.
+- Depending on `get` for a hot, correctness-affecting read (see the trigger note).
+```

--- a/skill/scripts/errands.ts
+++ b/skill/scripts/errands.ts
@@ -8,6 +8,8 @@
  *   claim     --id <ID> --owner <agent>
  *   resolve   --id <ID> --status done|failed|cancelled [--notes <text>]
  *   pending   [--kind <K>]
+ *   get       --id <ID>                    read one work_item as JSON (exit 1 if not found)
+ *   annotate  --id <ID> --notes-json <OBJ> merge a JSON object into the row's notes (metadata-only)
  *
  * Event emission lives in `lib/work-items.ts`, NOT here. The lib functions emit
  * `work_item_created` / `work_item_claimed` / `work_item_resolved` themselves so
@@ -26,6 +28,8 @@ import {
   resolveWorkItem,
   listWorkItems,
   listPending,
+  getWorkItem,
+  annotateWorkItem,
   type WorkItemStatus,
   type ResolveStatus,
 } from "./lib/work-items";
@@ -46,7 +50,7 @@ function printRow(row: unknown): void {
 
 function usage(): never {
   process.stderr.write(
-    "usage: errands.ts <list|enqueue|claim|resolve|pending> [...flags]\n",
+    "usage: errands.ts <list|enqueue|claim|resolve|pending|get|annotate> [...flags]\n",
   );
   process.exit(2);
 }
@@ -143,6 +147,40 @@ async function main(): Promise<void> {
       const kind = optionalString(rest, "kind");
       const rows = listPending(db, kind);
       for (const r of rows) printRow(r);
+      return;
+    }
+    case "get": {
+      const id = requireString(rest, "id");
+      const row = getWorkItem(db, id);
+      if (!row) {
+        process.stderr.write(`errands.ts get: no such work_item id=${id}\n`);
+        process.exit(1);
+      }
+      printRow(row);
+      return;
+    }
+    case "annotate": {
+      const id = requireString(rest, "id");
+      const notesJson = requireString(rest, "notes-json");
+      // Parse + shape-check here for a clearer error than the lib/SQL layer.
+      let patch: unknown;
+      try {
+        patch = JSON.parse(notesJson);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`invalid --notes-json (must be JSON): ${msg}\n`);
+        process.exit(2);
+      }
+      if (patch === null || typeof patch !== "object" || Array.isArray(patch)) {
+        process.stderr.write(
+          `invalid --notes-json: must be a JSON object (not an array or scalar)\n`,
+        );
+        process.exit(2);
+      }
+      // Lib merges into notes, bumps updated_at, and emits work_item_annotated itself —
+      // do NOT appendEvent here. Status/kind/payload are untouched by design.
+      const result = annotateWorkItem(db, id, patch as Record<string, unknown>);
+      printRow(result.row);
       return;
     }
     default:

--- a/skill/scripts/lib/work-items.ts
+++ b/skill/scripts/lib/work-items.ts
@@ -201,6 +201,91 @@ export function resolveWorkItem(
   return { row: updated, event };
 }
 
+export type AnnotateResult = { row: WorkItem; event: EventRow };
+
+/**
+ * Merge a host-supplied JSON object into a work_item's `notes` column and emit a
+ * `work_item_annotated` event. This is the KV-ish upsert surface hosts use to hang
+ * metadata (e.g. a `session_id`) off an existing work item — the errand→session map
+ * behind cortex#1720 S4b. It is deliberately metadata-only:
+ *
+ *   - It NEVER changes `status`, `kind`, `payload`, or `owner_agent`. Those are
+ *     bundle-owned; annotate touches `notes` + `updated_at` only.
+ *   - It is allowed on ANY status, terminal rows included. Unlike claim/resolve, an
+ *     annotation is not a state transition — recording a session id against a `done`
+ *     row is legitimate, so there is no terminal-status guard here.
+ *
+ * notes-as-JSON-object contract for this path:
+ *   - `patch` MUST be a plain JSON object. Arrays / scalars are rejected by the caller.
+ *   - Base object is derived from the existing `notes` cell:
+ *       · null / empty string        → base = {}
+ *       · valid JSON object          → base = that object
+ *       · anything else (non-JSON text, or JSON array/string/number) →
+ *         base = { text: <original raw string> }, preserving the operator's freeform
+ *         notes under a reserved `text` key rather than clobbering them.
+ *   - The merge is a SHALLOW override: keys in `patch` win over the base. Nested
+ *     objects are replaced wholesale, not deep-merged (keep the contract predictable).
+ *
+ * Audit trail: emits its own `work_item_annotated` event (payload `{ keys }` — the
+ * top-level keys written by this call). Per the events-are-lib-owned rule in this
+ * file's header, CLI/programmatic callers MUST NOT also appendEvent for this.
+ */
+export function annotateWorkItem(
+  db: Database,
+  id: string,
+  patch: Record<string, unknown>,
+): AnnotateResult {
+  const row = getWorkItem(db, id);
+  if (!row) {
+    throw new Error(`annotateWorkItem: no such work_item id=${id}`);
+  }
+  const base = notesToObject(row.notes);
+  const merged = { ...base, ...patch };
+  const ts = nowMs();
+  db.query(
+    `UPDATE work_items
+       SET notes = ?,
+           updated_at = ?
+     WHERE id = ?`,
+  ).run(JSON.stringify(merged), ts, id);
+  const updated = getWorkItem(db, id);
+  if (!updated) {
+    throw new Error(`annotateWorkItem: row vanished post-update (id=${id})`);
+  }
+  const event = appendEvent(db, {
+    type: "work_item_annotated",
+    actor: updated.owner_agent,
+    work_item_id: id,
+    payload: { keys: Object.keys(patch) },
+    ts,
+  });
+  return { row: updated, event };
+}
+
+/**
+ * Coerce a `notes` cell into a base object for annotate-merge.
+ *   - null / empty          → {}
+ *   - JSON object           → the object
+ *   - non-JSON, or JSON      → { text: <raw string> } (preserve freeform notes)
+ *     array/scalar
+ */
+function notesToObject(notes: string | null): Record<string, unknown> {
+  if (notes === null || notes.length === 0) return {};
+  try {
+    const parsed: unknown = JSON.parse(notes);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // fall through — non-JSON text
+  }
+  return { text: notes };
+}
+
 export function getWorkItem(db: Database, id: string): WorkItem | null {
   return (
     db


### PR DESCRIPTION
Closes #12

Additive CLI surface on `errands.ts` so hosts can use `work_items` as the errand→session map behind [cortex#1720 S4b](https://github.com/the-metafactory/cortex/issues/1720) — the read-by-id + metadata-upsert the assessment names as the blocker for retiring `dev-session-store.ts`.

## What's new

- **`errands.ts get <id>`** — prints one `work_item` as JSON. Exits `1` (distinct from the `2` used for flag/usage errors) with `no such work_item id=<id>` when missing. Exposes the existing (previously unexposed) lib `getWorkItem`.
- **`errands.ts annotate <id> --notes-json='{...}'`** — shallow-merges a JSON object into the row's `notes`. Metadata-only: bumps `updated_at`, **never** touches `status`/`kind`/`payload`/`owner_agent`, and is allowed on **any** status (terminal included) because annotation is not a state transition.
- **`lib/work-items.ts:annotateWorkItem`** emits its own `work_item_annotated` event (payload `{ keys }`) per the events-are-lib-owned rule in the file header — the CLI never double-emits.

## notes-merge contract (as implemented)

`notes` is `TEXT`; the annotate path treats it as a JSON object. Base for the merge:

| Existing `notes`             | Base                                  |
|------------------------------|---------------------------------------|
| `NULL` / empty               | `{}`                                  |
| valid JSON object            | that object                           |
| non-JSON freeform text       | `{ "text": "<original raw string>" }` |
| JSON array / string / number | `{ "text": "<original raw string>" }` |

Patch keys win (shallow override; nested objects replaced wholesale). The `text` key is **reserved** — operator freeform notes are preserved, never clobbered. `--notes-json` must be a JSON **object** (arrays/scalars → exit `2`; malformed JSON → exit `2`).

**Field ownership:** hosts may write host-namespaced `notes` keys (e.g. `session_id`); `status`/`kind`/`payload` are bundle-owned and structurally unreachable via annotate.

## Constraints honored

- No schema migration (the `notes` column already exists).
- `events` table semantics untouched — `work_item_annotated` is an additive new type.
- `CHECK` constraints unchanged.
- Follows existing `skill/scripts/` + `lib/` style (CLI parses/validates for clear errors, lib owns transitions + events).

## Docs

- New `skill/Workflows/AnnotateWorkItem.md` (Trigger/Action/Verify/Anti-pattern) — carries the notes-merge contract + field-ownership table + the cortex#1720 hot-path caveat (durable backing here; keep the hot read in-process).
- New `skill/Workflows/GetWorkItem.md`.
- `arc-manifest.yaml` (errands description + two new workflows), `README.md`, `skill/SKILL.md` updated.

## Tests

Baseline 81 → **99 pass / 0 fail** (+18), typecheck clean. New coverage: get found/not-found, annotate merge + event emission, non-JSON-notes preservation, JSON-array-notes preservation, terminal-status annotation allowed + status unchanged, kind/payload/owner untouched, `updated_at` bump, and CLI bad-input exit codes.

Does **not** bump versions; **not** merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)