### PR TITLE
chore(manifest): normalize to strict arc/v1 + wire validate-manifest CI (#15)

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,0 +1,14 @@
+# Strict arc/v1 manifest validation — the shared CI floor for skill repos
+# (skill-estate migration WS2, the-metafactory/arc#316). The reusable workflow
+# installs a pinned arc and runs `arc validate` over this repo's
+# arc-manifest.yaml; any strict-contract violation fails the check, one line
+# each. Pinned by 40-hex commit SHA (a branch/tag ref is movable) per the
+# metafactory-actions caller-usage README.
+name: validate-manifest
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  validate:
+    uses: the-metafactory/metafactory-actions/.github/workflows/validate-manifest.yml@94f76b1e191c430289ec2516746ef23623e9b7c4

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -3,10 +3,12 @@
 
 schema: arc/v1
 type: skill
-namespace: metafactory
+namespace: "@metafactory"
 name: agent-state
 version: 0.3.0
+tier: custom
 description: "Agent state primitive — work_items, events, dashboard, retros for persona-driven agents."
+license: MIT
 
 author:
   name: Andreas Aastroem
@@ -69,7 +71,15 @@ provides:
       description: "Generate weekly ISO-week retro from events"
 
 capabilities:
+  # Per-instance state.sqlite, dashboard.md, and retros/ live under $MF_INSTANCE_DIR.
   filesystem:
-    - path: $MF_INSTANCE_DIR
-      access: read-write
-      reason: "Per-instance state.sqlite, dashboard.md, retros/ live here"
+    read:
+      - "$MF_INSTANCE_DIR/**"
+    write:
+      - "$MF_INSTANCE_DIR/**"
+  network: []
+  # The scripts do their SQLite/dashboard work in-process (bun:sqlite) — no
+  # subprocess spawning.
+  bash:
+    allowed: false
+  secrets: []


### PR DESCRIPTION
Closes #15. Manifest normalization to the strict arc/v1 contract — **no rename** (grandfathered registered component, keeps its bare name). Part of the skill-estate migration epic (arc#316).

## Why

The strict validator (arc#317) rejected this repo's manifest. This joins it to the contract; no layout or CLI/skill content changes.

## Changes (`arc-manifest.yaml`)

- **capabilities**: rewritten to the required shape — `filesystem: { read: [], write: [] }` (was a list of `{ path, access, reason }`), plus the previously-absent `network: []`, `bash: { allowed: false }`, and `secrets: []`. `bash: false` is honest — the scripts do their SQLite/dashboard work in-process (`bun:sqlite`), with no subprocess spawning (confirmed in `skill/scripts/scaffold.ts`).
- **tier**: added `custom` (was absent; strict validator requires it) — follows the metafactory-soma-skill-handoff pathfinder precedent for a principal-authored skill.
- **license**: added `MIT` (was absent in the manifest; matches the repo's `LICENSE` file).
- **namespace**: `metafactory` → `@metafactory` (DD-15 `@scope` grammar; the issue also allowed removing it — I chose `@metafactory` for consistency with the other normalized manifests).

Author already correct (`Andreas Aastroem` / `mellanon` — we author this repo). Name `agent-state` is derivation-exempt (bare/grandfathered name), and `skill/SKILL.md` frontmatter `AgentState` already matches its PascalCase.

Wired the metafactory-actions `validate-manifest` reusable workflow as CI, SHA-pinned (`94f76b1e...`).

## Verification

- **`arc validate` → exit 0** (previously 7 violations: tier, license, all four capabilities sub-blocks, namespace).
- **Install round-trip (XDG-isolated)**: `✅ Installed agent-state v0.3.0`; `arc list --json` → `name=agent-state version=0.3.0 type=skill status=active`. (Installed from the normalized tree via `file://` — network egress is blocked in the executor session.)
- **repos.yaml accuracy**: the existing `agent-state` entry is accurate (public, correct url/type) — no change needed (no rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
